### PR TITLE
Don't create labels that already exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ module.exports = robot => {
     const config = yaml.safeLoad(Buffer.from(content.data.content, 'base64').toString())
 
     const files = await context.github.pullRequests.getFiles(context.issue())
-    const currentLabels = new Set((await context.github.issues.getIssueLabels(context.issue())).data.map((label) => {label.name}));
+    const currentLabelsResponse = await context.github.issues.getIssueLabels(context.issue())
+    const currentLabels = new Set(currentLabelsResponse.data.map((label) => { return label.name }))
     const changedFiles = files.data.map(file => file.filename)
     const labels = new Set()
 
@@ -25,10 +26,10 @@ module.exports = robot => {
         labels.add(label)
       }
     }
-    let labelsToAdd = [];
+    let labelsToAdd = []
     labels.forEach((label) => {
       if (!currentLabels.has(label)) {
-        labelsToAdd.push(label);
+        labelsToAdd.push(label)
       }
     })
 

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ module.exports = robot => {
     const config = yaml.safeLoad(Buffer.from(content.data.content, 'base64').toString())
 
     const files = await context.github.pullRequests.getFiles(context.issue())
+    const currentLabels = new Set((await context.github.issues.getIssueLabels(context.issue())).data.map((label) => {label.name}));
     const changedFiles = files.data.map(file => file.filename)
-
     const labels = new Set()
 
     // eslint-disable-next-line guard-for-in
@@ -25,8 +25,12 @@ module.exports = robot => {
         labels.add(label)
       }
     }
-
-    const labelsToAdd = Array.from(labels)
+    let labelsToAdd = [];
+    labels.forEach((label) => {
+      if (!currentLabels.has(label)) {
+        labelsToAdd.push(label);
+      }
+    })
 
     robot.log('Adding labels', labelsToAdd)
     if (labelsToAdd.length > 0) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "ignore": "^3.3.3",
     "js-yaml": "^3.9.0",
-    "probot": "^5.0.0"
+    "probot": "^7.0.0"
   },
   "devDependencies": {
     "jest": "^22.2.2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,4 @@
-const {createRobot} = require('probot')
+const {Application} = require('probot')
 const plugin = require('..')
 
 const config = `
@@ -8,15 +8,15 @@ frontend: ["*.js"]
 `
 
 describe('autolabeler', () => {
-  let robot
+  let app
   let github
 
   beforeEach(() => {
     // Create a new Robot to run our plugin
-    robot = createRobot()
+    app = new Application()
 
     // Load the plugin
-    plugin(robot)
+    app.load(plugin)
 
     // Mock out the GitHub API
     github = {
@@ -47,14 +47,14 @@ describe('autolabeler', () => {
     }
 
     // Mock out GitHub App authentication and return our mock client
-    robot.auth = () => Promise.resolve(github)
+    app.auth = () => Promise.resolve(github)
   })
 
   describe('pull_request.opened event', () => {
     const event = require('./fixtures/pull_request.opened')
 
     test('adds label', async () => {
-      await robot.receive(event)
+      await app.receive(event)
 
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'robotland',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,7 +39,10 @@ describe('autolabeler', () => {
       },
 
       issues: {
-        addLabels: jest.fn()
+        addLabels: jest.fn(),
+        getIssueLabels: jest.fn().mockImplementation(() => Promise.resolve({
+          data: [{name: 'config'}]
+        }))
       }
     }
 
@@ -63,7 +66,7 @@ describe('autolabeler', () => {
         owner: 'robotland',
         repo: 'test',
         number: 98,
-        labels: ['test', 'config']
+        labels: ['test']
       })
     })
   })


### PR DESCRIPTION
I've updated the probot to not create labels when they already exist.
Creating labels that already exist results in unnecessary labelling events on the PR/Issue.