### PR TITLE
Update jest to v23.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "probot": "^5.0.0"
   },
   "devDependencies": {
-    "jest": "^22.2.2",
+    "jest": "^23.6.0",
     "smee-client": "^1.0.1",
     "standard": "^11.0.0"
   },


### PR DESCRIPTION
When cloning the repo, running `npm install` and `npm test`, the following error is reported:

```
❯ npm test

> probot-labeler@1.0.0 test /Users/macklinu/dev/probot/autolabeler
> jest && standard

 FAIL  test/index.test.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.527s
Ran all test suites.
npm ERR! Test failed.  See above for more details.
```

I believe this is due to https://github.com/facebook/jest/issues/6766, so updating to the latest version of Jest resolves this and allows me to run the test suite locally.