### PR TITLE
chore: remove probot deprecation warnings 🧼

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const yaml = require('js-yaml')
 const ignore = require('ignore')
 
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on('pull_request.opened', autolabel)
   app.on('pull_request.synchronize', autolabel)
   app.on('pull_request.reopened', autolabel)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,7 @@ describe('autolabeler', () => {
   beforeEach(() => {
     nock.disableNetConnect()
     probot = new Probot({
-      id: 1,
+      appId: 1,
       githubToken: 'test',
       // Disable throttling & retrying requests for easier testing
       Octokit: ProbotOctokit.defaults({


### PR DESCRIPTION
👋🏼 

Starting looking the code of the app I was facing some deprecation warnings

![Screenshot 2023-10-03 at 19 25 40](https://github.com/mithro/autolabeler/assets/3717296/2425c22e-c24a-44ce-b64b-e682daa437c1)

Here are the two fixes, and tada 🎉 

<img width="518" alt="image" src="https://github.com/mithro/autolabeler/assets/3717296/780529f5-0923-4e57-8b43-1bca21e7f31e">